### PR TITLE
pdfoutline: correct typo in man page 

### DIFF
--- a/scripts/pdfoutline.1.in
+++ b/scripts/pdfoutline.1.in
@@ -58,7 +58,7 @@ Document title
 .SH BUGS
 Due to a bug in Perl library \fBPDF::API2 v2.039\fP and earlier, some
 Unicode characters are handled incorrectly and cause outline string
-corruptions. For example, everything after the CJK character U+6B63 (正)
+corruptions. For example, everything after the CJK character U+4E0A (上)
 will get corrupted in the PDF output because its UTF-16 encoding contains
 byte 0x0A, which happens to be an ASCII newline character.
 .P


### PR DESCRIPTION
I just found I accidentally used the wrong character in the man page explanation of the character corruption bug. I corrected the git commit message before sending the first pull request, but forgot to correct the actual man page. This pull request fixes it. This is likely not a big deal, but I think it's important to maintain documentation correctness as a matter of principle. Thanks for your patience.

P.S: please ignore pull request #17, I created and closed it by accident.