### PR TITLE
Use SPDX license identifiers in file headers

### DIFF
--- a/scripts/pdf-extract-outline.pl
+++ b/scripts/pdf-extract-outline.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/env perl
-# This file is in the public domain
 # Author: Ievgenii Meshcheriakov <eugen@debian.org>
+# SPDX-License-Identifier: CC-PDDC
 #
 # This program extracts outlines from PDF files. The outlines
 # are stored into a text file that could be used with pdfoutline

--- a/scripts/pdfoutline.pl
+++ b/scripts/pdfoutline.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/env perl
-# This file is in public domain
 # Author: Ievgenii Meshcheriakov <eugen@debian.org>
+# SPDX-License-Identifier: CC-PDDC
 #
 # This program adds outlines to pdf files.
 # Usage: pdfoutline input.pdf outline.txt out.pdf

--- a/src/fntsample.c
+++ b/src/fntsample.c
@@ -1,17 +1,5 @@
 /* Copyright © Євгеній Мещеряков <eugen@debian.org>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 #include <assert.h>
 // TODO: freetype 2.10.3, do not include ft2build.h anymore

--- a/src/gen_unicode_blocks.c
+++ b/src/gen_unicode_blocks.c
@@ -1,17 +1,5 @@
 /* Copyright © Євгеній Мещеряков <eugen@debian.org>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 #include "unicode_blocks.h"
 #include <stdio.h>

--- a/src/read_blocks.c
+++ b/src/read_blocks.c
@@ -1,17 +1,5 @@
 /* Copyright © Євгеній Мещеряков <eugen@debian.org>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 #include "unicode_blocks.h"
 #include <stdio.h>

--- a/src/static_unicode_blocks.h
+++ b/src/static_unicode_blocks.h
@@ -1,6 +1,6 @@
 /*
- * This file is in public domain
  * Author: Ievgenii Meshcheriakov <eugen@debian.org>
+ * SPDX-License-Identifier: CC-PDDC
  */
 #ifndef STATIC_UNICODE_BLOCKS_H
 #define STATIC_UNICODE_BLOCKS_H

--- a/src/unicode_blocks.h
+++ b/src/unicode_blocks.h
@@ -1,6 +1,6 @@
 /*
- * This file is in public domain
  * Author: Ievgenii Meshcheriakov <eugen@debian.org>
+ * SPDX-License-Identifier: CC-PDDC
  */
 #ifndef UNICODE_BLOCKS_H
 #define UNICODE_BLOCKS_H


### PR DESCRIPTION
This reduces sizes of those headers.

SPDX can be found here: https://spdx.dev